### PR TITLE
Fix instructions with template changelogs at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ When creating a pull request, you must include changelog notes in one of two for
 /changelog minor
 ### Added 
 * new feature X
+
 ### Updated 
 * component Y
 /-changelog
@@ -28,6 +29,7 @@ When creating a pull request, you must include changelog notes in one of two for
 
 ### Added 
 * new feature X
+
 ### Updated 
 * component Y
 


### PR DESCRIPTION
/changelog

### Fixed
* Sections in examples are now appropriately split with additional enwline