### PR TITLE
Add support for Makrdown syntax

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -51,6 +51,116 @@ jobs:
       - name: Extract changes since last tag
         id: changes
         run: | #shell
+          function decho() {
+            if [ ! -z "$CHANGELOG_DEBUG" ]; then
+              echo "Debug:" "$@" 1>&2
+            fi
+          }
+
+          function extract_section() {
+            local SOURCE_TEXT=$1
+            
+            if echo "$SOURCE_TEXT" | grep -qi '/changelog'; then
+              decho "found /changelog"
+              if echo "$SOURCE_TEXT" | grep -qi '/-changelog'; then
+                decho "found /-changelog"
+                RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/\/changelog/I,/\/-changelog/Ip'`
+              else
+                decho "fallback without /-changelog"
+                RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/\/changelog/I,$p'`
+              fi
+            else
+              decho "no /changelog found"
+              RAW_CHANGELOG_SECTION=
+            fi
+
+            # If no changelog section found, try getting it from ## Changelog and ---
+            if [ -z "$RAW_CHANGELOG_SECTION" ]; then
+              decho "starting ## Changelog and --- checks"
+              if echo "$SOURCE_TEXT" | grep -qi '## Changelog'; then
+                decho "found ## Changelog"
+                if echo "$SOURCE_TEXT" | grep -q -- '---'; then
+                  decho "found ---"
+                  RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/## Changelog/I,/---/p'`
+                  if [ -z "$RAW_CHANGELOG_SECTION" ]; then
+                    decho "fallback without ---"
+                    RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/## Changelog/I,$p'`
+                  fi
+                else
+                  decho "fallback without ---"
+                  RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/## Changelog/I,$p'`
+                fi
+              else
+                decho "no ## Changelog found"
+                RAW_CHANGELOG_SECTION=
+              fi
+            fi
+
+            # If no changelog section found, try getting it from <details><summary>Changelog {patch|minor|major}</summary>...</details> tag
+            if [ -z "$RAW_CHANGELOG_SECTION" ]; then
+              decho "starting <details><summary>Changelog checks"
+              if echo "$SOURCE_TEXT" | grep -qi '<details><summary>Changelog'; then
+                decho "found <details><summary>Changelog"
+                RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/<details><summary>Changelog/I,/<\/details>/Ip'`
+              fi
+            fi
+
+            if [ -z "$RAW_CHANGELOG_SECTION" ]; then
+              echo -e "No changelog section. Use /changelog {patch|minor|major} followed by your changelog notes" 1>&2
+              if [ ! -z "$EXAMPLE_CHANGELOG" ]; then
+                echo -e "Example changelog section:\n$EXAMPLE_CHANGELOG" 1>&2
+              fi
+              exit 1
+            fi
+            echo "$RAW_CHANGELOG_SECTION"
+          }
+
+          function extract_changelog() {
+            local SOURCE_TEXT=$1
+            local CHANGELOG_NOTE=`echo "$SOURCE_TEXT" | grep -vi '/changelog' | grep -vi '/-changelog' | grep -vi '<details><summary>Changelog' | grep -vi '</details>' | grep -vi '## Changelog' | grep -v -- '---'`
+
+            if [ -z "$CHANGELOG_NOTE" ]; then
+              echo -e "No changelog notes found changelog section. Use /changelog {patch|minor|major} followed by your changelog notes" 1>&2
+              if [ ! -z "$EXAMPLE_CHANGELOG" ]; then
+                echo -e "Example changelog section:\n$EXAMPLE_CHANGELOG" 1>&2
+              fi
+              exit 1
+            fi
+
+            echo "$CHANGELOG_NOTE"
+          }
+
+          function extract_change_level() {
+            local SOURCE_TEXT=$1
+            if echo "$SOURCE_TEXT" | grep -i '/changelog' | grep -qiE 'patch|minor|major'; then
+              CHANGE_LEVEL=`echo "$SOURCE_TEXT" | grep -i '/changelog' | grep -iEo 'patch|minor|major'`
+            elif echo "$SOURCE_TEXT" | grep -i '## Changelog' | grep -qiE 'patch|minor|major'; then
+              CHANGE_LEVEL=`echo "$SOURCE_TEXT" | grep -i '## Changelog' | grep -iEo 'patch|minor|major'`
+            elif echo "$SOURCE_TEXT" | grep -i '<details><summary>Changelog' | grep -qiE 'patch|minor|major'; then
+              CHANGE_LEVEL=`echo "$SOURCE_TEXT" | grep -i '<details><summary>Changelog' | grep -iEo 'patch|minor|major'`
+            else
+              CHANGE_LEVEL="${DEFAULT_CHANGE_LEVEL:-patch}"
+            fi
+            echo "$CHANGE_LEVEL"
+          }
+
+           function get_max_change_level() {
+            local CHANGE_LEVEL=$1
+            local OTHER_CHANGE_LEVEL=$2
+
+            if [ -z "$CHANGE_LEVEL" ] && [ ! -z "$OTHER_CHANGE_LEVEL" ]; then
+              CHANGE_LEVEL="$OTHER_CHANGE_LEVEL"
+            elif [ "$CHANGE_LEVEL" == "patch" ]; then
+              # if change level is patch, set commit change level
+              CHANGE_LEVEL="$OTHER_CHANGE_LEVEL"
+            elif [ "$CHANGE_LEVEL" == "minor" ] && [ "$OTHER_CHANGE_LEVEL" == "major" ]; then
+              # if change level is minor, and current is major, set current
+              CHANGE_LEVEL="$OTHER_CHANGE_LEVEL"
+            fi
+            
+            echo "$CHANGE_LEVEL"
+          }
+
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [[ -n "$PREVIOUS_TAG" ]]; then
             GIT_RANGE="${PREVIOUS_TAG}..HEAD"
@@ -66,24 +176,18 @@ jobs:
           
           for COMMIT in $(git rev-list $GIT_RANGE); do
             COMMIT_MSG=$(git log --format=%B -n 1 $COMMIT)
-            
-            if echo "$COMMIT_MSG" | grep -q '/changelog\|<details><summary>Changelog'; then
-              if echo "$COMMIT_MSG" | grep -q '/changelog'; then
-                NOTE=$(echo "$COMMIT_MSG" | sed -n '/\/changelog/,/\/-changelog/p' | grep -v '/changelog')
-                LEVEL=$(echo "$COMMIT_MSG" | grep '/changelog' | grep -Eo 'patch|minor|major' || echo "patch")
-              else
-                NOTE=$(echo "$COMMIT_MSG" | awk '/<details><summary>Changelog/,/<\/details>/' | sed '1d;$d')
-                LEVEL=$(echo "$COMMIT_MSG" | grep '<details><summary>Changelog' | grep -Eo 'patch|minor|major' || echo "patch")
-              fi
-              
-              if [[ "$LEVEL" == "major" ]] || [[ "$CHANGE_LEVEL" == "patch" ]]; then
-                CHANGE_LEVEL="$LEVEL"
-              elif [[ "$LEVEL" == "minor" ]] && [[ "$CHANGE_LEVEL" == "patch" ]]; then
-                CHANGE_LEVEL="minor"
-              fi
-              
-              echo "$NOTE" >> $TEMP_FILE
+
+            if ! RAW_CHANGELOG_SECTION=`extract_section "$COMMIT_MSG"`; then
+              continue;
             fi
+            if ! CHANGELOG_NOTE=`extract_changelog "$RAW_CHANGELOG_SECTION"`; then
+              continue;
+            fi
+            COMMIT_CHANGE_LEVEL=`extract_change_level "$RAW_CHANGELOG_SECTION"`
+              
+            CHANGE_LEVEL=`get_max_change_level "$CHANGE_LEVEL" "$COMMIT_CHANGE_LEVEL"`
+
+            echo "$NOTE" >> $TEMP_FILE
           done
           
           echo "notes=$(cat $TEMP_FILE)"

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -129,7 +129,7 @@ jobs:
             exit 1
           fi
           
-          RAW_CHANGELOG_SECTION=`extract_section "$CI_MERGE_REQUEST_DESCRIPTION"`
+          RAW_CHANGELOG_SECTION=`extract_section "$PR_DESCRIPTION"`
           CHANGELOG_NOTE=`extract_changelog "$RAW_CHANGELOG_SECTION"`
           COMMIT_CHANGE_LEVEL=`extract_change_level "$RAW_CHANGELOG_SECTION"`
           

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -31,31 +31,112 @@ jobs:
           DELIMITER: "EOF_CHANGELOG"
           CHANGELOG_FILE: ${{ inputs.changelog-file }}
         run: | #shell
+          function decho() {
+            if [ ! -z "$CHANGELOG_DEBUG" ]; then
+              echo "Debug:" "$@" 1>&2
+            fi
+          }
+
+          function extract_section() {
+            local SOURCE_TEXT=$1
+            
+            if echo "$SOURCE_TEXT" | grep -qi '/changelog'; then
+              decho "found /changelog"
+              if echo "$SOURCE_TEXT" | grep -qi '/-changelog'; then
+                decho "found /-changelog"
+                RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/\/changelog/I,/\/-changelog/Ip'`
+              else
+                decho "fallback without /-changelog"
+                RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/\/changelog/I,$p'`
+              fi
+            else
+              decho "no /changelog found"
+              RAW_CHANGELOG_SECTION=
+            fi
+
+            # If no changelog section found, try getting it from ## Changelog and ---
+            if [ -z "$RAW_CHANGELOG_SECTION" ]; then
+              decho "starting ## Changelog and --- checks"
+              if echo "$SOURCE_TEXT" | grep -qi '## Changelog'; then
+                decho "found ## Changelog"
+                if echo "$SOURCE_TEXT" | grep -q -- '---'; then
+                  decho "found ---"
+                  RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/## Changelog/I,/---/p'`
+                  if [ -z "$RAW_CHANGELOG_SECTION" ]; then
+                    decho "fallback without ---"
+                    RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/## Changelog/I,$p'`
+                  fi
+                else
+                  decho "fallback without ---"
+                  RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/## Changelog/I,$p'`
+                fi
+              else
+                decho "no ## Changelog found"
+                RAW_CHANGELOG_SECTION=
+              fi
+            fi
+
+            # If no changelog section found, try getting it from <details><summary>Changelog {patch|minor|major}</summary>...</details> tag
+            if [ -z "$RAW_CHANGELOG_SECTION" ]; then
+              decho "starting <details><summary>Changelog checks"
+              if echo "$SOURCE_TEXT" | grep -qi '<details><summary>Changelog'; then
+                decho "found <details><summary>Changelog"
+                RAW_CHANGELOG_SECTION=`echo "$SOURCE_TEXT" | sed -n '/<details><summary>Changelog/I,/<\/details>/Ip'`
+              fi
+            fi
+
+            if [ -z "$RAW_CHANGELOG_SECTION" ]; then
+              echo -e "No changelog section. Use /changelog {patch|minor|major} followed by your changelog notes" 1>&2
+              if [ ! -z "$EXAMPLE_CHANGELOG" ]; then
+                echo -e "Example changelog section:\n$EXAMPLE_CHANGELOG" 1>&2
+              fi
+              exit 1
+            fi
+            echo "$RAW_CHANGELOG_SECTION"
+          }
+
+          function extract_changelog() {
+            local SOURCE_TEXT=$1
+            local CHANGELOG_NOTE=`echo "$SOURCE_TEXT" | grep -vi '/changelog' | grep -vi '/-changelog' | grep -vi '<details><summary>Changelog' | grep -vi '</details>' | grep -vi '## Changelog' | grep -v -- '---'`
+
+            if [ -z "$CHANGELOG_NOTE" ]; then
+              echo -e "No changelog notes found changelog section. Use /changelog {patch|minor|major} followed by your changelog notes" 1>&2
+              if [ ! -z "$EXAMPLE_CHANGELOG" ]; then
+                echo -e "Example changelog section:\n$EXAMPLE_CHANGELOG" 1>&2
+              fi
+              exit 1
+            fi
+
+            echo "$CHANGELOG_NOTE"
+          }
+
+          function extract_change_level() {
+            local SOURCE_TEXT=$1
+            if echo "$SOURCE_TEXT" | grep -i '/changelog' | grep -qiE 'patch|minor|major'; then
+              CHANGE_LEVEL=`echo "$SOURCE_TEXT" | grep -i '/changelog' | grep -iEo 'patch|minor|major'`
+            elif echo "$SOURCE_TEXT" | grep -i '## Changelog' | grep -qiE 'patch|minor|major'; then
+              CHANGE_LEVEL=`echo "$SOURCE_TEXT" | grep -i '## Changelog' | grep -iEo 'patch|minor|major'`
+            elif echo "$SOURCE_TEXT" | grep -i '<details><summary>Changelog' | grep -qiE 'patch|minor|major'; then
+              CHANGE_LEVEL=`echo "$SOURCE_TEXT" | grep -i '<details><summary>Changelog' | grep -iEo 'patch|minor|major'`
+            else
+              CHANGE_LEVEL="${DEFAULT_CHANGE_LEVEL:-patch}"
+            fi
+            echo "$CHANGE_LEVEL"
+          }
+
           if [[ -z "$PR_DESCRIPTION" ]]; then
             echo "Error: PR description is empty"
             exit 1
           fi
           
-          if echo "$PR_DESCRIPTION" | grep -q '/changelog'; then
-            if echo "$PR_DESCRIPTION" | grep -q '/-changelog'; then
-              RAW_CHANGELOG="$(echo "$PR_DESCRIPTION" | awk '/\/changelog/,/\/-changelog/' | sed '1d;$d')"
-            else
-              RAW_CHANGELOG="$(echo "$PR_DESCRIPTION" | awk '/\/changelog/,0' | sed '1d')"
-            fi
-          elif echo "$PR_DESCRIPTION" | grep -q '<details><summary>Changelog'; then
-            RAW_CHANGELOG="$(echo "$PR_DESCRIPTION" | awk '/<details><summary>Changelog/,/<\/details>/' | sed '1d;$d')"
-          else
-            echo "Error: No changelog section found"
-            echo "Use /changelog {patch|minor|major} followed by your changelog notes"
-            exit 1
-          fi
-          
-          CHANGE_LEVEL="$(echo "$PR_DESCRIPTION" | grep -E '/changelog|<details>' | grep -Eo 'patch|minor|major' || echo "patch")"
+          RAW_CHANGELOG_SECTION=`extract_section "$CI_MERGE_REQUEST_DESCRIPTION"`
+          CHANGELOG_NOTE=`extract_changelog "$RAW_CHANGELOG_SECTION"`
+          COMMIT_CHANGE_LEVEL=`extract_change_level "$RAW_CHANGELOG_SECTION"`
           
           {
-            echo "level=$CHANGE_LEVEL"
+            echo "level=$COMMIT_CHANGE_LEVEL"
             echo "note<<$DELIMITER"
-            echo "$RAW_CHANGELOG"
+            echo "$CHANGELOG_NOTE"
             echo "$DELIMITER"
           } >> $GITHUB_OUTPUT
 

--- a/README.md
+++ b/README.md
@@ -12,30 +12,39 @@ The workflow automatically manages changelog entries through pull requests and r
 
 ### Adding Changelog Entries
 
-When creating a pull request, you must include changelog notes in one of two formats:
+This workflow supports 3 main extraction methods from PR description: **Command syntax**, **Markdown syntax**, and **Collapsible syntax**. In Command and markdown syntax variants, endint is optional. All variants are **case insensitive**.
 
-1. Using changelog tags:
+Command syntax
 ```markdown
-/changelog minor
-### Added 
-* new feature X
+/changelog [patch|minor|major]
 
-### Updated 
-* component Y
-/-changelog
+### Added
+* features
+<!-- and so on -->
+
+/-changelog <!-- optional - if not present, we'll grab everything after command start -->
 ```
 
-2. Using details element:
+Markdown syntax
 ```markdown
-<details><summary>Changelog minor</summary>
+## Changelog [patch|minor|major]
 
-### Added 
-* new feature X
+### Added
+* features
+<!-- and so on -->
 
-### Updated 
-* component Y
+--- <!-- optional - if not present, we'll grab everything after Changelog header -->
+```
 
-</details>
+Collapsed `details` syntax
+```markdown
+<details><summary>Changelog [patch|minor|major]</summary>
+
+### Added
+* features
+<!-- and so on -->
+
+<details>
 ```
 
 The change level must be one of:
@@ -107,7 +116,7 @@ If the PR validation fails, check:
       
       jobs:
       validate:
-         uses: happy-changelog/happy-changelog-workflow/.github/workflows/validate-changelog.yml@v1.2.0
+         uses: happy-changelog/happy-changelog-workflow/.github/workflows/validate-changelog.yml@v1.3.0
          permissions:
             pull-requests: read
             contents: read
@@ -126,7 +135,7 @@ If the PR validation fails, check:
       
       jobs:
       update:
-         uses: happy-changelog/happy-changelog-workflow/.github/workflows/update-changelog.yml@v1.2.0
+         uses: happy-changelog/happy-changelog-workflow/.github/workflows/update-changelog.yml@v1.3.0
          permissions:
             contents: write
          with:
@@ -146,7 +155,7 @@ If the PR validation fails, check:
       
       jobs:
       release:
-         uses: happy-changelog/happy-changelog-workflow/.github/workflows/edit-release.yml@v1.2.0
+         uses: happy-changelog/happy-changelog-workflow/.github/workflows/edit-release.yml@v1.3.0
          permissions:
             contents: write
          with:


### PR DESCRIPTION
## Description
Add support for Makrdown syntax by integrating same bash code as in GL CI

## Changelog: minor

### Added
* Support for markdown pattern: `Changelog` header as block start, and horizontal line as optional block end

### Changed
* Patterns now are not case sensitive
* All major code is now aligned with gitlab ci

---

someafetertext
