### PR TITLE
Add ability to detect pr template and error when it happens

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,13 @@
 ## Description
 <!-- Provide a brief description of the changes in this PR -->
 
-<!-- Remove the comments and fill in changelog
-<details><summary>Changelog: minor</summary>
+## Changelog: patch|minor|major
 
 ### Added 
-* new feature X
+* 
+<!-- etc -->
 
-### Updated 
-* component Y
-
-</details>
--->
+---
 
 ## Related Issues
 <!-- Link any related issues here using #issue-number -->

--- a/.github/workflows/local-validate-changelog.yml
+++ b/.github/workflows/local-validate-changelog.yml
@@ -12,3 +12,4 @@ jobs:
       contents: read
     with:
       changelog-file: CHANGELOG.md
+      error-on-template: 'Changelog: patch|minor|major'

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -136,8 +136,8 @@ jobs:
           fi
 
           if [ ! -z "$ERROR_ON_TEMPLATE" ]; then
-            if echo "$CI_MERGE_REQUEST_DESCRIPTION" | grep -qi -- "$ERROR_ON_TEMPLATE"; then
-              echo "Your MR description contains an MR template $ERROR_ON_TEMPLATE. Please fill out the description and include correct Changelog section in it." 1>&2
+            if echo "$PR_DESCRIPTION" | grep -qi -- "$ERROR_ON_TEMPLATE"; then
+              echo "Your PR description contains an MR template $ERROR_ON_TEMPLATE. Please fill out the description and include correct Changelog section in it." 1>&2
               exit 1
             fi
           fi

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: 'CHANGELOG.md'
+      error-on-template:
+        description: 'Error message when provided MR template string is found in the description'
+        required: false
+        type: string
+        default: ''
     outputs:
       level:
         description: 'Detected change level (patch, minor, major)'
@@ -30,6 +35,7 @@ jobs:
           PR_DESCRIPTION: ${{ github.event.pull_request.body }}
           DELIMITER: "EOF_CHANGELOG"
           CHANGELOG_FILE: ${{ inputs.changelog-file }}
+          ERROR_ON_TEMPLATE: ${{ inputs.error-on-template }}
         run: | #shell
           function decho() {
             if [ ! -z "$CHANGELOG_DEBUG" ]; then
@@ -127,6 +133,13 @@ jobs:
           if [[ -z "$PR_DESCRIPTION" ]]; then
             echo "Error: PR description is empty"
             exit 1
+          fi
+
+          if [ ! -z "$ERROR_ON_TEMPLATE" ]; then
+            if echo "$CI_MERGE_REQUEST_DESCRIPTION" | grep -qi -- "$ERROR_ON_TEMPLATE"; then
+              echo "Your MR description contains an MR template $ERROR_ON_TEMPLATE. Please fill out the description and include correct Changelog section in it." 1>&2
+              exit 1
+            fi
           fi
           
           RAW_CHANGELOG_SECTION=`extract_section "$PR_DESCRIPTION"`

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The change level must be one of:
    - Validates the changelog entry format
    - Ensures changelog notes are present
    - Checks for valid change level
+   - Optionally, allows PR rejection if changelog is only a template (with `error-on-template` input)
 
 ![](./docs/pr-checks.png)
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If the PR validation fails, check:
       
       jobs:
       validate:
-         uses: happy-changelog/happy-changelog-workflow/.github/workflows/validate-changelog.yml@v1.3.0
+         uses: happy-changelog/happy-changelog-workflow/.github/workflows/validate-changelog.yml@v1.4.0
          permissions:
             pull-requests: read
             contents: read
@@ -135,7 +135,7 @@ If the PR validation fails, check:
       
       jobs:
       update:
-         uses: happy-changelog/happy-changelog-workflow/.github/workflows/update-changelog.yml@v1.3.0
+         uses: happy-changelog/happy-changelog-workflow/.github/workflows/update-changelog.yml@v1.4.0
          permissions:
             contents: write
          with:
@@ -155,7 +155,7 @@ If the PR validation fails, check:
       
       jobs:
       release:
-         uses: happy-changelog/happy-changelog-workflow/.github/workflows/edit-release.yml@v1.3.0
+         uses: happy-changelog/happy-changelog-workflow/.github/workflows/edit-release.yml@v1.4.0
          permissions:
             contents: write
          with:


### PR DESCRIPTION
## Description
Basic ability to reject PR if it the description contains only template changelog

## Changelog: minor

### Added 
* User can now add `error-on-template` input for `validate-changelog` which will return error if PR description contains PR template instead of actual Changelog and description

---