### PR TITLE
Enhance workflows with post-version script support

### DIFF
--- a/.github/workflows/local-update-changelog.yml
+++ b/.github/workflows/local-update-changelog.yml
@@ -16,7 +16,7 @@ jobs:
       target-branch: main
       version-title-template: 'v:{version} - {date}'
       post-version-script: |
-        for WORKFLOW in "validate-changelog" "update-changelog" "release"; do
+        for WORKFLOW in "validate-changelog" "update-changelog" "edit-release"; do
           COMPONENT_PATH="happy-changelog/happy-changelog-workflow/.github/workflows/${WORKFLOW}.yml"
           sed -i "s|${COMPONENT_PATH}@[a-zA-Z0-9._-]*|${COMPONENT_PATH}@v${NEW_VERSION}|g" README.md
         done

--- a/.github/workflows/local-update-changelog.yml
+++ b/.github/workflows/local-update-changelog.yml
@@ -15,3 +15,9 @@ jobs:
       enable-npm-version: true
       target-branch: main
       version-title-template: 'v:{version} - {date}'
+      post-version-script: |
+        for WORKFLOW in "validate-changelog" "update-changelog" "release"; do
+          COMPONENT_PATH="happy-changelog/happy-changelog-workflow/.github/workflows/${WORKFLOW}.yml"
+          sed -i "s|${COMPONENT_PATH}@[a-zA-Z0-9._-]*|${COMPONENT_PATH}@v${NEW_VERSION}|g" README.md
+        done
+        git add README.md

--- a/.github/workflows/local-validate-changelog.yml
+++ b/.github/workflows/local-validate-changelog.yml
@@ -13,3 +13,9 @@ jobs:
     with:
       changelog-file: CHANGELOG.md
       error-on-template: 'Changelog: patch|minor|major'
+      post-version-script: |
+        for WORKFLOW in "validate-changelog" "update-changelog" "release"; do
+          COMPONENT_PATH="happy-changelog/happy-changelog-workflow/.github/workflows/${WORKFLOW}.yml"
+          sed -i "s|${COMPONENT_PATH}@[a-zA-Z0-9._-]*|${COMPONENT_PATH}@v${NEW_VERSION}|g" README.md
+        done
+        git add README.md

--- a/.github/workflows/local-validate-changelog.yml
+++ b/.github/workflows/local-validate-changelog.yml
@@ -14,7 +14,7 @@ jobs:
       changelog-file: CHANGELOG.md
       error-on-template: 'Changelog: patch|minor|major'
       post-version-script: |
-        for WORKFLOW in "validate-changelog" "update-changelog" "release"; do
+        for WORKFLOW in "validate-changelog" "update-changelog" "edit-release"; do
           COMPONENT_PATH="happy-changelog/happy-changelog-workflow/.github/workflows/${WORKFLOW}.yml"
           sed -i "s|${COMPONENT_PATH}@[a-zA-Z0-9._-]*|${COMPONENT_PATH}@v${NEW_VERSION}|g" README.md
         done

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -24,7 +24,7 @@ on:
         type: string
         default: 'v:{version} - {date}'
       post-version-script:
-        description: 'Array of bash commands to execute after version update but before changes are committed. Available variables: $NEW_VERSION - new semantic version, $NEW_VERSION_CHANGES - changelog content for this version, $CHANGE_LEVEL - change level (patch/minor/major), $CHANGELOG_FILE - path to changelog file.'
+        description: 'Bash script to execute after version update but before changes are committed. Available variables: $NEW_VERSION - new semantic version, $NEW_VERSION_CHANGES - changelog content for this version, $CHANGE_LEVEL - change level (patch/minor/major), $CHANGELOG_FILE - path to changelog file.'
         required: false
         type: string
         default: ''

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: 'v:{version} - {date}'
+      post-version-script:
+        description: 'Array of bash commands to execute after version update but before changes are committed. Available variables: $NEW_VERSION - new semantic version, $NEW_VERSION_CHANGES - changelog content for this version, $CHANGE_LEVEL - change level (patch/minor/major), $CHANGELOG_FILE - path to changelog file.'
+        required: false
+        type: string
+        default: ''
     outputs:
       new_version:
         description: 'New version number'
@@ -223,6 +228,10 @@ jobs:
         id: version
         run: | #shell
           NEW_VERSION=$(npx --yes changelog-tools ${{ inputs.changelog-file }} | jq -r '.versions[0].version')
+          NEW_VERSION_CHANGES=$(npx --yes changelog-tools ${{ inputs.changelog-file }} | jq -r '.versions[0].body')
+          CHANGE_LEVEL="${{ steps.changes.outputs.level }}"
+          CHANGELOG_FILE="${{ inputs.changelog-file }}"
+          
           echo "Updating version..."
           echo "New version: $NEW_VERSION"
           
@@ -231,6 +240,13 @@ jobs:
             git add package.json
           fi
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Run post-version script
+        if: steps.changes.outputs.notes != '' && inputs.post-version-script != ''
+        run: |
+          # Execute the post-version script if provided
+          echo "Running post-version script..."
+          ${{ inputs.post-version-script }}
 
       - name: Commit changes
         if: steps.changes.outputs.notes != ''

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -13,6 +13,16 @@ on:
         required: false
         type: string
         default: ''
+      post-version-script:
+        description: 'Array of bash commands to execute after version update but before changes are committed. Available variables: $NEW_VERSION - new semantic version, $NEW_VERSION_CHANGES - changelog content for this version, $CHANGE_LEVEL - change level (patch/minor/major), $CHANGELOG_FILE - path to changelog file.'
+        required: false
+        type: string
+        default: ''
+      run-post-version-script-in-pr:
+        description: 'Whether to run post-version-script in PR validation job to preview changes'
+        required: false
+        type: boolean
+        default: true
     outputs:
       level:
         description: 'Detected change level (patch, minor, major)'
@@ -166,3 +176,50 @@ jobs:
           
           echo "✅ Valid changelog found ($LEVEL)"
           echo "$NOTES"
+
+      - name: Preview version changes
+        if: inputs.run-post-version-script-in-pr == true && inputs.post-version-script != ''
+        env:
+          NOTES: ${{ steps.extract-changelog.outputs.note }}
+          LEVEL: ${{ steps.extract-changelog.outputs.level }}
+          CHANGELOG_FILE: ${{ inputs.changelog-file }}
+        run: | #shell
+          # Create a temporary changelog file for preview
+          TEMP_CHANGELOG=$(mktemp)
+          if [ ! -f $CHANGELOG_FILE ]; then
+            echo "# Changelog" > $TEMP_CHANGELOG
+          else
+            cp $CHANGELOG_FILE $TEMP_CHANGELOG
+          fi
+          
+          # Add the new changelog entry
+          CURRENT_DATE=$(date '+%Y-%m-%d')
+          TITLE_TEMPLATE="v:{version} - {date}"
+          FORMATTED_TITLE="${TITLE_TEMPLATE/\{version\}/$LEVEL}"
+          FORMATTED_TITLE="${FORMATTED_TITLE/\{date\}/$CURRENT_DATE}"
+          
+          npx --yes changelog-tools add $TEMP_CHANGELOG \
+            -t "$FORMATTED_TITLE" \
+            --new-changelog "$NOTES" \
+            -o $TEMP_CHANGELOG
+          
+          # Calculate new version and changes
+          NEW_VERSION=$(npx --yes changelog-tools $TEMP_CHANGELOG | jq -r '.versions[0].version')
+          NEW_VERSION_CHANGES=$(npx --yes changelog-tools $TEMP_CHANGELOG | jq -r '.versions[0].body')
+          CHANGE_LEVEL=$LEVEL
+          
+          echo "Preview of changes that would be made:"
+          echo "New version would be: $NEW_VERSION"
+          echo "Changes would be:"
+          echo "$NEW_VERSION_CHANGES"
+          
+          # Run post-version script if enabled
+          if [ "${{ inputs.run-post-version-script-in-pr }}" == "true" ]; then
+            echo "Running post-version script preview..."
+            ${{ inputs.post-version-script }}
+          fi
+          
+          # Show git diff in collapsible section
+          echo "::group::Git changes preview"
+          git diff --cached
+          echo "::endgroup::"

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -177,6 +177,13 @@ jobs:
           echo "✅ Valid changelog found ($LEVEL)"
           echo "$NOTES"
 
+      - name: Checkout repository
+        if: inputs.run-post-version-script-in-pr == true && inputs.post-version-script != ''
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
       - name: Preview version changes
         if: inputs.run-post-version-script-in-pr == true && inputs.post-version-script != ''
         env:

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: ''
       post-version-script:
-        description: 'Array of bash commands to execute after version update but before changes are committed. Available variables: $NEW_VERSION - new semantic version, $NEW_VERSION_CHANGES - changelog content for this version, $CHANGE_LEVEL - change level (patch/minor/major), $CHANGELOG_FILE - path to changelog file.'
+        description: 'Bash script to execute after version update but before changes are committed. Available variables: $NEW_VERSION - new semantic version, $NEW_VERSION_CHANGES - changelog content for this version, $CHANGE_LEVEL - change level (patch/minor/major), $CHANGELOG_FILE - path to changelog file.'
         required: false
         type: string
         default: ''

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.gitlab-ci.yml

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ If the PR validation fails, check:
             contents: read
          with:
             changelog-file: CHANGELOG.md
+            # Optional: Reject PR if description contains template text
+            error-on-template: 'Changelog: patch|minor|major'
+            # Optional: Run custom script after version update
+            post-version-script: |
+              # Example: Update workflow references in documentation
+              # This script updates version references in README.md when a new version is released
+              REFERENCE_TO_UPDATE=happy-changelog/happy-changelog-workflow/.github/workflows/update-changelog.yml
+              sed -i "s|${REFERENCE_TO_UPDATE}@[a-zA-Z0-9._-]*|${REFERENCE_TO_UPDATE}@v${NEW_VERSION}|g" README.md
+              git add README.md
       ```
       - Update changelog and `package.json` after merge/commit into `main`
       ```yaml
@@ -144,6 +153,13 @@ If the PR validation fails, check:
             enable-npm-version: true
             target-branch: main
             version-title-template: 'v:{version} - {date}'
+            # Optional: Run custom script after version update
+            post-version-script: |
+              # Example: Update workflow references in documentation
+              # This script updates version references in README.md when a new version is released
+              REFERENCE_TO_UPDATE=happy-changelog/happy-changelog-workflow/.github/workflows/update-changelog.yml
+              sed -i "s|${REFERENCE_TO_UPDATE}@[a-zA-Z0-9._-]*|${REFERENCE_TO_UPDATE}@v${NEW_VERSION}|g" README.md
+              git add README.md
       ```
       - After publishing a release, update it's description, to contain changelog since previous release
       ```yaml


### PR DESCRIPTION
## Description
This change improves flexibility in managing version updates and documentation consistency.

## Changelog: minor

### Added 
* Added `post-version-script` input to various workflows to allow custom scripts to run after version updates.

### Removed
* Removed `.gitlab-ci.yml` from `.gitignore` as it is no longer needed.

---
